### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/me.iepure.devtoolbox.json
+++ b/me.iepure.devtoolbox.json
@@ -1,7 +1,7 @@
 {
     "id" : "me.iepure.devtoolbox",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "devtoolbox",
     "separate-locales": false,


### PR DESCRIPTION
tested with `flatpak run --runtime-version=48 me.iepure.devtoolbox`