### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/me.iepure.devtoolbox.json
+++ b/me.iepure.devtoolbox.json
@@ -13,17 +13,6 @@
         "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-run/gvfsd"
     ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules" : [
     	{
             "name": "python312",


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.
